### PR TITLE
Restricting pages in the Admin folder to admin roles

### DIFF
--- a/src/DevBetterWeb.Web/Pages/Admin/Index.cshtml.cs
+++ b/src/DevBetterWeb.Web/Pages/Admin/Index.cshtml.cs
@@ -1,14 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DevBetterWeb.Core;
 using DevBetterWeb.Web.Areas.Identity.Data;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace DevBetterWeb.Web.Pages.Admin
 {
+    [Authorize(Roles = AuthConstants.Roles.ADMINISTRATORS)]
     public class IndexModel : PageModel
     {
         private readonly UserManager<ApplicationUser> _userManager;

--- a/src/DevBetterWeb.Web/Pages/Admin/Role.cshtml.cs
+++ b/src/DevBetterWeb.Web/Pages/Admin/Role.cshtml.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DevBetterWeb.Core;
 using DevBetterWeb.Web.Areas.Identity.Data;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace DevBetterWeb.Web.Pages.Admin
 {
+    [Authorize(Roles = AuthConstants.Roles.ADMINISTRATORS)]
     public class RoleModel : PageModel
     {
         private readonly UserManager<ApplicationUser> _userManager;

--- a/src/DevBetterWeb.Web/Pages/Admin/User.cshtml.cs
+++ b/src/DevBetterWeb.Web/Pages/Admin/User.cshtml.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DevBetterWeb.Core;
 using DevBetterWeb.Web.Areas.Identity.Data;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace DevBetterWeb.Web.Pages.Admin
 {
+    [Authorize(Roles = AuthConstants.Roles.ADMINISTRATORS)]
     public class UserModel : PageModel
     {
         private readonly UserManager<ApplicationUser> _userManager;


### PR DESCRIPTION
- Previously if you manually changed the URL to go to one of the admin screens, you would be able to see them.